### PR TITLE
Fix tool page link in SUMMARY.md.

### DIFF
--- a/content/SUMMARY.md
+++ b/content/SUMMARY.md
@@ -8,7 +8,7 @@
 * [Environment](meta/environment.md)
   * [Mac](meta/mac.md)
   * [Linux](meta/linux.md)
-* [Tools](/content/tools/index.md)
+* [Tools](tools/index.md)
   * [Code Sniffer](/tools/code-sniffer.md)
 * [Git](git/index.md)
   * [Merge Conflicts](git/merge.md)


### PR DESCRIPTION
Tools page link is broken in sidebar.

<img width="329" alt="screen shot 2017-12-28 at 5 11 25 pm" src="https://user-images.githubusercontent.com/10358350/34409813-39cb254a-ebf2-11e7-82ad-6282ad37e952.png">
